### PR TITLE
Change debian dependencies

### DIFF
--- a/src/debian/control
+++ b/src/debian/control
@@ -16,7 +16,7 @@ Package: dkms
 Architecture: all
 Provides: dkms, apprecovery-dkms
 Depends: ${misc:Depends},
- module-init-tools,
+ module-init-tools | kmod,
  gcc,
  make | build-essential | dpkg-dev,
  coreutils (>= 7.4),


### PR DESCRIPTION
- Changed debian builds to require either module-init-tools or kmod, as for 16.04 has kmod by default
  @ekovalenko-softheme please review
