### PR TITLE
Skip reading config while remove module [RR-101934] (master)

### DIFF
--- a/src/dkms
+++ b/src/dkms
@@ -515,8 +515,10 @@ read_conf()
     [[ $conf ]] && read_conf_file="$conf"
     [[ $3 ]] && read_conf_file="$3"
 
-    [[ -r $read_conf_file ]] || die 4 $"Could not locate dkms.conf file." \
-    $"File: $conf does not exist."
+    if [[ -r $read_conf_file ]]; then
+        echo "Could not locate dkms.conf file. File: $read_conf_file does not exist."
+        return 4
+    fi
 
     [[ $last_mvka = $module/$module_version/$1/$2 && \
     $last_mvka_conf = $(readlink -f $read_conf_file) ]] && return
@@ -1867,7 +1869,7 @@ remove_module()
         fi
 
         # Read the conf file
-        read_conf_or_die "${kernelver[$i]}" "${arch[$i]}"
+        read_conf "${kernelver[$i]}" "${arch[$i]}" || continue
 
         do_uninstall "${kernelver[$i]}" "${arch[$i]}"
 


### PR DESCRIPTION
- If read_conf cannot be found dkms.conf file - skip this step and continue process

Jira: [RR-101934](https://jira.labs.quest.com/browse/RR-101934)
@asuvorov-softheme @ekovalenko-softheme 