### PR TITLE
Fix issue "does not represent a valid dkms.conf file" [RR-104350] (master)

### DIFF
--- a/src/dkms
+++ b/src/dkms
@@ -1586,7 +1586,7 @@ remove_weak_links()
 is_module_added() {
     [[ $1 && $2 ]] || return 1
     [[ -d $dkms_tree/$1/$2 ]] || return 2
-    [[ -L $dkms_tree/$1/$2/source || -d $dkms_tree/$1/$2/source ]];
+    [[ -L $dkms_tree/$1/$2/source && -d $dkms_tree/$1/$2/source ]];
 }
 
 is_module_built() {


### PR DESCRIPTION
- If path /var/lib/dkms/rapidrecovery-vss/ case some empty directories with empty
symlink to /var/lib/dkms/rapidrecovery-vss/<version>/source dkms will raise error:
"does not represent a valid dkms.conf file" because dkms script will be looking for
the synlink to nonexistent path OR nonexistent directory

Jira: RR-104350
@asuvorov-softheme 
@ekovalenko-softheme